### PR TITLE
update nbbpm.compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nodebb-theme-slick",
   "version": "1.2.1",
   "nbbpm": {
-    "compatibility": "^1.8.0"
+    "compatibility": "^1.9.0"
   },
   "description": "Slick theme for NodeBB",
   "main": "theme.less",


### PR DESCRIPTION
5fa6638bbc34f69b5475339f0084879ecefb1195 already applied by @barisusakli, other breaking changes do not apply as they reference templates that slick does not overwrite and can inherit from Persona.