### PR TITLE
deduplicate chat options menu

### DIFF
--- a/templates/chat.tpl
+++ b/templates/chat.tpl
@@ -4,36 +4,7 @@
 			<div class="modal-header">
 				<button id="chat-close-btn" type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true"><i class="fa fa-times"></i></span></button>
 				<button type="button" class="close hidden-xs hidden-sm" data-action="maximize"><span aria-hidden="true"><i class="fa fa-expand"></i></span><span class="sr-only">[[modules:chat.maximize]]</span></button>
-
-				<div class="dropdown pull-right">
-					<button class="close" data-toggle="dropdown" component="chat/controlsToggle"><i class="fa fa-gear"></i></button>
-					<ul class="dropdown-menu dropdown-menu-right pull-right" component="chat/controls">
-						<!-- IF users.length -->
-						<li class="dropdown-header">[[modules:chat.in-room]]</li>
-						<!-- BEGIN users -->
-						<li>
-							<a href="{config.relative_path}/uid/{../uid}">
-								<!-- IF ../picture -->
-								<img class="avatar avatar-sm" component="user/picture" src="{../picture}" itemprop="image" />
-								<!-- ELSE -->
-								<div class="avatar avatar-sm" component="user/picture" style="background-color: {../icon:bgColor};">{../icon:text}</div><!-- END -->{../username}
-							</a>
-						</li>
-						<!-- END -->
-						<li role="separator" class="divider"></li>
-						<!-- END -->
-						<li class="dropdown-header">[[modules:chat.options]]</li>
-						<li>
-							<a href="#" data-action="members"><i class="fa fa-fw fa-cog"></i> [[modules:chat.manage-room]]</a>
-						</li>
-						<li>
-							<a href="#" data-action="rename"><i class="fa fa-fw fa-edit"></i> [[modules:chat.rename-room]]</a>
-						</li>
-						<li>
-							<a href="#" data-action="leave"><i class="fa fa-fw fa-sign-out"></i> [[modules:chat.leave]]</a>
-						</li>
-					</ul>
-				</div>
+				<!-- IMPORT partials/chats/options.tpl -->
 
 				<h4 component="chat/room/name"><!-- IF roomName -->{roomName}<!-- ELSE -->{usernames}<!-- ENDIF roomName --></h4>
 			</div>


### PR DESCRIPTION
This change is necessary for the new version of nodebb-plugin-global-chat. (I've already made the same change to the other main themes).

Core depends on partials/chats/message-window,
but slick has no such template,
so it falls back to the persona version.
In that case, it should be fine to not include partials/chats/options,
and it will just use the persona version of that as well.